### PR TITLE
Added support for elements with display property 'none'

### DIFF
--- a/cmelo-sticky.js
+++ b/cmelo-sticky.js
@@ -43,6 +43,8 @@ angular.module('cmelo.angularSticky', [])
 					var stickers = [];
 
 					angular.forEach(stickers_all, function (sticker) {
+						if(sticker.offsetParent === null)
+							return;
 						var parent = getClosest(sticker, 'cmelo-sticky');
 						if (parent === elem.eq(0)[0]) {
 							stickers.push(sticker);


### PR DESCRIPTION
Found a case where a table was not displayed which caused an "Uncaught TypeError: Cannot read property 'offsetTop' of null." to be thrown. This simply ignores sticky elements whose parents are not visible.